### PR TITLE
[codex] refine theme switching experience

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,6 +34,8 @@
   --tilt-y: 0deg;
   --spot-x: 50%;
   --spot-y: 0%;
+  --theme-x: calc(100vw - 74px);
+  --theme-y: 42px;
 }
 
 html.light {
@@ -53,6 +55,27 @@ html.light {
   --accent-2: #0f8f83;
   --shadow: 0 24px 80px rgba(31, 36, 40, 0.1);
   --shadow-soft: 0 12px 36px rgba(31, 36, 40, 0.08);
+}
+
+html.cyber {
+  color-scheme: dark;
+  --bg: #07110f;
+  --bg-2: #091a16;
+  --surface: #0b211c;
+  --surface-2: #102d25;
+  --paper: #06100d;
+  --ink: #dfffee;
+  --text: #e7fff1;
+  --muted: #94b9a6;
+  --faint: #618274;
+  --line: rgba(137, 255, 194, 0.13);
+  --line-strong: rgba(137, 255, 194, 0.25);
+  --accent: #7dffb5;
+  --accent-2: #55d9f2;
+  --danger: #ff7d91;
+  --ok: #9affc4;
+  --shadow: 0 24px 80px rgba(0, 10, 7, 0.42);
+  --shadow-soft: 0 12px 36px rgba(0, 10, 7, 0.3);
 }
 
 *,
@@ -80,6 +103,17 @@ body {
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition:
+    color 420ms var(--ease),
+    background-color 420ms var(--ease),
+    border-color 420ms var(--ease);
+}
+
+html.cyber body {
+  background:
+    linear-gradient(180deg, rgba(125, 255, 181, 0.035), transparent 22%),
+    linear-gradient(90deg, rgba(85, 217, 242, 0.025), transparent 38%, rgba(125, 255, 181, 0.02)),
+    linear-gradient(180deg, var(--bg), var(--bg-2));
 }
 
 button,
@@ -147,6 +181,82 @@ main {
   height: 3px;
   background: linear-gradient(90deg, var(--accent), var(--accent-2));
   box-shadow: 0 0 18px color-mix(in srgb, var(--accent) 42%, transparent);
+}
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+::view-transition-old(root) {
+  z-index: 1;
+}
+
+::view-transition-new(root) {
+  z-index: 2;
+}
+
+.theme-transition-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  contain: strict;
+}
+
+.theme-transition-orb {
+  position: absolute;
+  left: var(--theme-x);
+  top: var(--theme-y);
+  width: 24vmax;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in srgb, var(--accent) 42%, transparent);
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle,
+      color-mix(in srgb, var(--surface) 96%, var(--accent) 4%) 0 42%,
+      color-mix(in srgb, var(--surface) 74%, transparent) 62%,
+      transparent 72%
+    );
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, white 7%, transparent) inset,
+    0 0 72px color-mix(in srgb, var(--accent) 16%, transparent);
+  filter: blur(1px) saturate(1.08);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0.05);
+  will-change: transform, opacity;
+}
+
+.theme-transition-sheen {
+  position: absolute;
+  inset: -30%;
+  background: linear-gradient(
+    108deg,
+    transparent 32%,
+    color-mix(in srgb, white 10%, transparent) 45%,
+    color-mix(in srgb, var(--accent-2) 8%, transparent) 50%,
+    transparent 62%
+  );
+  opacity: 0;
+  transform: translateX(-48%) rotate(-7deg);
+  mix-blend-mode: soft-light;
+  will-change: transform, opacity;
+}
+
+html.theme-switching .theme-transition-layer {
+  opacity: 1;
+}
+
+html.theme-switching .theme-transition-orb {
+  animation: theme-bloom 720ms var(--ease-out) both;
+}
+
+html.theme-switching .theme-transition-sheen {
+  animation: theme-sheen 660ms 70ms var(--ease-out) both;
 }
 
 .effect-stage {
@@ -397,6 +507,131 @@ main {
 .icon-button {
   width: 38px;
   height: 38px;
+}
+
+.theme-toggle {
+  --theme-index: 1;
+  position: relative;
+  width: 104px;
+  height: 38px;
+  padding: 3px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 90%, transparent);
+  color: var(--muted);
+  box-shadow:
+    0 8px 22px color-mix(in srgb, black 11%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 9%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, black 3%, transparent);
+  cursor: pointer;
+  transition:
+    transform 180ms var(--ease-out),
+    border-color 220ms var(--ease),
+    background 220ms var(--ease),
+    box-shadow 220ms var(--ease);
+}
+
+.theme-toggle[data-theme="light"] {
+  --theme-index: 0;
+}
+
+.theme-toggle[data-theme="dark"] {
+  --theme-index: 1;
+}
+
+.theme-toggle[data-theme="cyber"] {
+  --theme-index: 2;
+}
+
+.theme-toggle-track {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  align-items: center;
+}
+
+.theme-toggle-glow {
+  position: absolute;
+  right: 8px;
+  bottom: -2px;
+  left: 8px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent), var(--accent-2), transparent);
+  opacity: 0.45;
+  filter: blur(1px);
+}
+
+.theme-toggle-indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background:
+    linear-gradient(145deg, color-mix(in srgb, var(--text) 96%, white 4%), color-mix(in srgb, var(--text) 86%, var(--accent) 14%));
+  box-shadow:
+    0 4px 12px color-mix(in srgb, black 22%, transparent),
+    0 1px 2px color-mix(in srgb, black 16%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
+  transform: translateX(calc(var(--theme-index) * 32px));
+  transition:
+    transform 520ms var(--ease-out),
+    background 420ms var(--ease),
+    box-shadow 420ms var(--ease);
+  will-change: transform;
+}
+
+.theme-toggle-option {
+  position: relative;
+  z-index: 1;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--faint);
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1;
+  opacity: 0.72;
+  transform: scale(0.92);
+  cursor: pointer;
+  transition:
+    color 280ms var(--ease),
+    opacity 280ms var(--ease),
+    transform 420ms var(--ease-out);
+}
+
+.theme-toggle-terminal {
+  font-size: 0.66rem;
+  font-weight: 900;
+}
+
+.theme-toggle-option.active {
+  color: var(--bg);
+  opacity: 1;
+  transform: scale(1);
+}
+
+.theme-toggle:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--line));
+  background: color-mix(in srgb, var(--surface) 80%, var(--accent) 4%);
+  box-shadow:
+    0 12px 28px color-mix(in srgb, black 15%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.theme-toggle:active {
+  transform: translateY(0) scale(0.985);
 }
 
 .nav-chip,
@@ -2033,6 +2268,37 @@ html.light .shiki code .line span {
   }
 }
 
+@keyframes theme-bloom {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.05);
+  }
+  20% {
+    opacity: 0.92;
+  }
+  72% {
+    opacity: 0.72;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(8);
+  }
+}
+
+@keyframes theme-sheen {
+  0% {
+    opacity: 0;
+    transform: translateX(-48%) rotate(-7deg);
+  }
+  38% {
+    opacity: 0.54;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(48%) rotate(-7deg);
+  }
+}
+
 pre[class*="language-"]::before,
 .shiki[data-language]::before {
   content: attr(data-language);
@@ -2051,10 +2317,13 @@ html.transitioning *,
 html.transitioning *::before,
 html.transitioning *::after {
   transition:
-    background-color 80ms ease,
-    color 80ms ease,
-    border-color 80ms ease,
-    box-shadow 80ms ease !important;
+    background-color 460ms var(--ease),
+    color 460ms var(--ease),
+    border-color 460ms var(--ease),
+    box-shadow 460ms var(--ease),
+    fill 460ms var(--ease),
+    stroke 460ms var(--ease),
+    transform 520ms var(--ease-out) !important;
 }
 
 .sr-only {
@@ -2128,6 +2397,21 @@ html.transitioning *::after {
   .icon-button {
     width: 36px;
     height: 36px;
+  }
+
+  .theme-toggle {
+    width: 101px;
+    height: 36px;
+  }
+
+  .theme-toggle-indicator,
+  .theme-toggle-option {
+    width: 28px;
+    height: 28px;
+  }
+
+  .theme-toggle-indicator {
+    transform: translateX(calc(var(--theme-index) * 31px));
   }
 
   .nav-center {
@@ -2221,5 +2505,9 @@ html.transitioning *::after {
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .theme-transition-layer {
+    display: none;
   }
 }

--- a/components/AppNav.vue
+++ b/components/AppNav.vue
@@ -46,14 +46,52 @@
             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
           </svg>
         </a>
-        <button
-          class="icon-button"
-          type="button"
-          :aria-label="isThemeReady && !isDark ? 'Switch to dark mode' : 'Switch to light mode'"
-          @click="toggleTheme()"
+        <div
+          class="theme-toggle"
+          role="group"
+          aria-label="主题"
+          :data-theme="isThemeReady ? themeMode : 'dark'"
+          data-allow-mismatch="attribute"
         >
-          <span aria-hidden="true" data-allow-mismatch="text" v-html="isThemeReady && !isDark ? '&#9790;' : '&#9788;'" />
-        </button>
+          <span class="theme-toggle-track">
+            <span class="theme-toggle-glow" />
+            <span class="theme-toggle-indicator" />
+            <button
+              class="theme-toggle-option"
+              :class="{ active: themeMode === 'light' }"
+              type="button"
+              aria-label="纸感浅色"
+              title="纸感浅色"
+              :aria-pressed="themeMode === 'light'"
+              @click="setTheme('light', $event)"
+            >
+              <span aria-hidden="true">☼</span>
+            </button>
+            <button
+              class="theme-toggle-option"
+              :class="{ active: themeMode === 'dark' }"
+              type="button"
+              aria-label="暖黑深色"
+              title="暖黑深色"
+              :aria-pressed="themeMode === 'dark'"
+              @click="setTheme('dark', $event)"
+            >
+              <span aria-hidden="true">☾</span>
+            </button>
+            <button
+              class="theme-toggle-option theme-toggle-terminal"
+              :class="{ active: themeMode === 'cyber' }"
+              type="button"
+              aria-label="荧光终端"
+              title="荧光终端"
+              :aria-pressed="themeMode === 'cyber'"
+              @click="setTheme('cyber', $event)"
+            >
+              <span aria-hidden="true">&gt;_</span>
+            </button>
+          </span>
+          <span class="sr-only" data-allow-mismatch="text">{{ themeLabel }}</span>
+        </div>
       </div>
     </div>
   </nav>
@@ -63,9 +101,15 @@
 const appConfig = useAppConfig()
 const route = useRoute()
 
-const isDark = inject<Ref<boolean>>('isDark', ref(true))
 const isThemeReady = inject<Ref<boolean>>('isThemeReady', ref(false))
-const toggleTheme = inject<() => void>('toggleTheme', () => {})
+const themeMode = inject<Ref<'dark' | 'light' | 'cyber'>>('themeMode', ref('dark'))
+const setTheme = inject<(mode: 'dark' | 'light' | 'cyber', event?: MouseEvent) => void>('setTheme', () => {})
+
+const themeLabel = computed(() => {
+  if (themeMode.value === 'light') return '纸感浅色'
+  if (themeMode.value === 'cyber') return '荧光终端'
+  return '暖黑深色'
+})
 
 function isActive(path: string): boolean {
   if (path === '/') return route.path === '/'

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,10 @@
 <template>
   <div id="app-root">
     <div id="reading-bar" />
+    <div class="theme-transition-layer" aria-hidden="true">
+      <span class="theme-transition-orb" />
+      <span class="theme-transition-sheen" />
+    </div>
     <SiteEffects />
     <AppNav />
     <main>
@@ -14,22 +18,47 @@
 <script setup lang="ts">
 const appConfig = useAppConfig()
 
+type ThemeMode = 'dark' | 'light' | 'cyber'
+type ThemeViewTransition = {
+  ready: Promise<void>
+  finished: Promise<void>
+}
+type ThemeTransitionDocument = Document & {
+  startViewTransition?: (callback: () => void) => ThemeViewTransition
+}
+
 // Theme state
 const isDark = ref(true)
 const isThemeReady = ref(false)
+const themeMode = ref<ThemeMode>('dark')
+const themeModes: ThemeMode[] = ['dark', 'light', 'cyber']
+let themeTimer: ReturnType<typeof window.setTimeout> | undefined
+
+function normalizeTheme(value: string | null): ThemeMode {
+  return value === 'light' || value === 'cyber' || value === 'dark' ? value : 'dark'
+}
+
+function applyTheme(mode: ThemeMode, persist = true) {
+  const h = document.documentElement
+  themeMode.value = mode
+  isDark.value = mode !== 'light'
+
+  h.classList.toggle('light', mode === 'light')
+  h.classList.toggle('dark', mode !== 'light')
+  h.classList.toggle('cyber', mode === 'cyber')
+  h.dataset.theme = mode
+  document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute('content', mode === 'light' ? '#f5f1e8' : mode === 'cyber' ? '#07110f' : '#101214')
+
+  if (persist) {
+    localStorage.setItem('theme', mode)
+  }
+}
 
 // Initialize theme from localStorage on client
 onMounted(() => {
-  const stored = localStorage.getItem('theme')
-  if (stored === 'light') {
-    isDark.value = false
-    document.documentElement.classList.remove('dark')
-    document.documentElement.classList.add('light')
-  } else {
-    isDark.value = true
-    document.documentElement.classList.add('dark')
-    document.documentElement.classList.remove('light')
-  }
+  const stored = normalizeTheme(localStorage.getItem('theme'))
+  applyTheme(stored, false)
   isThemeReady.value = true
 
   // Reading progress bar
@@ -55,22 +84,75 @@ onMounted(() => {
   }
 })
 
-// Toggle theme — 切换时加 transitioning class 统一覆盖为 80ms 快速过渡
-function toggleTheme() {
+// Apply a selected theme with a soft bloom from the interaction point.
+function setTheme(nextTheme: ThemeMode, event?: MouseEvent) {
   const h = document.documentElement
+  if (nextTheme === themeMode.value || h.classList.contains('transitioning')) return
+
+  const transitionDocument = document as ThemeTransitionDocument
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const x = event?.clientX ?? window.innerWidth - 74
+  const y = event?.clientY ?? 42
+
+  h.style.setProperty('--theme-x', x + 'px')
+  h.style.setProperty('--theme-y', y + 'px')
+  h.dataset.themeNext = nextTheme
   h.classList.add('transitioning')
-  isDark.value = !isDark.value
-  if (isDark.value) {
-    h.classList.add('dark')
-    h.classList.remove('light')
-    localStorage.setItem('theme', 'dark')
-  } else {
-    h.classList.remove('dark')
-    h.classList.add('light')
-    localStorage.setItem('theme', 'light')
+
+  if (themeTimer) window.clearTimeout(themeTimer)
+  const finishTransition = () => {
+    if (themeTimer) {
+      window.clearTimeout(themeTimer)
+      themeTimer = undefined
+    }
+    h.classList.remove('transitioning', 'theme-switching')
+    delete h.dataset.themeNext
   }
-  // 80ms 足够完成过渡，移除 class 后恢复元素各自的 hover 过渡
-  setTimeout(() => h.classList.remove('transitioning'), 80)
+
+  if (!reduceMotion && transitionDocument.startViewTransition) {
+    const transition = transitionDocument.startViewTransition(() => applyTheme(nextTheme))
+
+    transition.ready.then(() => {
+      const radius = Math.hypot(
+        Math.max(x, window.innerWidth - x),
+        Math.max(y, window.innerHeight - y),
+      )
+
+      h.animate(
+        {
+          clipPath: [
+            'circle(0px at ' + x + 'px ' + y + 'px)',
+            'circle(' + radius + 'px at ' + x + 'px ' + y + 'px)',
+          ],
+        },
+        {
+          duration: 580,
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+          pseudoElement: '::view-transition-new(root)',
+        } as KeyframeAnimationOptions & { pseudoElement: string },
+      )
+    }).catch(() => {})
+
+    transition.finished.then(finishTransition, finishTransition)
+    themeTimer = window.setTimeout(finishTransition, 760)
+    return
+  }
+
+  if (!reduceMotion) {
+    h.classList.add('theme-switching')
+    window.requestAnimationFrame(() => applyTheme(nextTheme))
+    themeTimer = window.setTimeout(finishTransition, 760)
+    return
+  }
+
+  applyTheme(nextTheme)
+  finishTransition()
+}
+
+function toggleTheme(event?: MouseEvent) {
+  const currentIndex = themeModes.indexOf(themeMode.value)
+  const nextTheme = themeModes[(currentIndex + 1) % themeModes.length]
+  setTheme(nextTheme, event)
 }
 
 // Keyboard shortcut: T to toggle theme
@@ -89,6 +171,8 @@ onMounted(() => {
 // Provide theme state to children
 provide('isDark', isDark)
 provide('isThemeReady', isThemeReady)
+provide('themeMode', themeMode)
+provide('setTheme', setTheme)
 provide('toggleTheme', toggleTheme)
 
 useHead({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -107,6 +107,7 @@ export default defineNuxtConfig({
       meta: [
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { charset: 'utf-8' },
+        { name: 'theme-color', content: '#101214' },
       ],
       link: [
         { rel: 'icon', type: 'image/svg+xml', sizes: 'any', href: '/favicon.svg?v=2' },
@@ -118,7 +119,7 @@ export default defineNuxtConfig({
       // 防主题闪烁：在 DOM 渲染前读取 localStorage 并立即应用主题 class
       script: [
         {
-          innerHTML: `(function(){var t=localStorage.getItem('theme');var h=document.documentElement;if(t==='light'){h.classList.add('light');}else{h.classList.add('dark');}})();`,
+          innerHTML: `(function(){var t=localStorage.getItem('theme');var h=document.documentElement;t=t==='light'||t==='cyber'||t==='dark'?t:'dark';h.dataset.theme=t;h.classList.toggle('light',t==='light');h.classList.toggle('dark',t!=='light');h.classList.toggle('cyber',t==='cyber');var m=document.querySelector('meta[name=theme-color]');if(m)m.setAttribute('content',t==='light'?'#f5f1e8':t==='cyber'?'#07110f':'#101214');})();`,
           type: 'text/javascript',
         },
       ],


### PR DESCRIPTION
## What changed

- replace the binary theme button with an accessible three-state segmented control
- add warm dark, paper light, and phosphor terminal palettes
- animate theme changes from the interaction point with the View Transition API and a graceful fallback
- persist the selected theme, prevent first-paint flashing, and sync the browser theme color
- respect reduced-motion preferences and keep the control responsive on mobile

## Why

The previous theme switch changed colors abruptly and offered limited visual feedback. This update gives the interaction a more refined, layered feel while retaining the site's existing visual identity.

## Validation

- `npm run build`
- desktop browser verification at 1280x720
- mobile browser verification at 390x844
- all three theme states, persistence after reload, ARIA state, and horizontal overflow checked
- no browser console errors
